### PR TITLE
added vocab of crossplane

### DIFF
--- a/Stakater/styles/config/vocabularies/Stakater/accept.txt
+++ b/Stakater/styles/config/vocabularies/Stakater/accept.txt
@@ -296,3 +296,5 @@ www
 xfs
 YAML
 Zerotier
+XR[s]
+XRD[s]


### PR DESCRIPTION
added 2 new words for crossplane

1. XR[s]
2. XRD[s] 