### PR TITLE
Replace expired token

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -13,9 +13,9 @@ jobs:
         with:
           fetch-depth: 0
       - name: Push Latest Tag
-        uses: anothrNick/github-tag-action@1.70.0
+        uses: anothrNick/github-tag-action@1.67.0
         env:
-          GITHUB_TOKEN: ${{ secrets.STAKATER_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.PUBLISH_TOKEN }}
           WITH_V: true
           DEFAULT_BUMP: patch
           RELEASE_BRANCHES: 'main'


### PR DESCRIPTION
The latest version of `anothrNick/github-tag-action` has an unresolved issue where it requires a token with unknown permissions, attempting an older version