### PR TITLE
feat(vocab): accept VAP/VAPs (ValidatingAdmissionPolicy)

### DIFF
--- a/Stakater/styles/config/vocabularies/Stakater/accept.txt
+++ b/Stakater/styles/config/vocabularies/Stakater/accept.txt
@@ -484,6 +484,7 @@ utilizations
 [Uu]til[s]?
 uuid
 Valkey
+VAP[s]?
 Vault
 vCenter
 vCluster


### PR DESCRIPTION
## What

Adds `VAP[s]?` to the Stakater spelling vocabulary (`Stakater/styles/config/vocabularies/Stakater/accept.txt`), slotted alphabetically next to the existing `VPA[s]?`.

## Why

`ValidatingAdmissionPolicy` is commonly abbreviated **VAP** in Kubernetes/OpenShift docs. The all-caps singular `VAP` already passes Vale's acronym handling, but the mixed-case plural **`VAPs`** is flagged as a spelling error — which blocks docs that discuss admission policies in prose (surfaced while writing handbook ADR-0057 on the hosted-cluster admission fence). `VAP[s]?` covers both forms and matches the existing `VPA[s]?` / `VLAN[s]?` convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)