### PR TITLE
feat(vocab): accept stakater-cloud terms org(s), bao, kcp

### DIFF
--- a/Stakater/styles/config/vocabularies/Stakater/accept.txt
+++ b/Stakater/styles/config/vocabularies/Stakater/accept.txt
@@ -33,6 +33,7 @@ bool
 [Bb]ackported
 BackupStorageLocation
 Bagares
+[Bb]ao
 [Bb]aremetal
 Binero
 Bitnami
@@ -218,6 +219,7 @@ kameletbinding[s]?
 Kaoto
 Karlskrona
 Katacoda
+kcp
 Kerberos
 [Kk]eycloak
 [Kk]eypair
@@ -315,6 +317,7 @@ OpenBao
 OpenMetal
 OpenShift
 OpenStack
+[Oo]rg[s]?
 OSD[s]?
 OTel
 overcommit


### PR DESCRIPTION
## What
Adds three recurring stakater-cloud platform terms to the Vale accept vocabulary:
- `[Oo]rg[s]?` — organizations shorthand
- `[Bb]ao` — OpenBao CLI/instance shorthand
- `kcp` — the kcp control-plane project

## Why
These appear throughout the stakater-cloud handbook docs (mesh/bao/kcp runbooks) and currently fail `Vale.Spelling`. Additive-only — cannot break downstream builds, only makes spell-check accept these domain terms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)