### PR TITLE
fix(vocab): accept both KCP and kcp casings

### DIFF
--- a/Stakater/styles/config/vocabularies/Stakater/accept.txt
+++ b/Stakater/styles/config/vocabularies/Stakater/accept.txt
@@ -219,7 +219,7 @@ kameletbinding[s]?
 Kaoto
 Karlskrona
 Katacoda
-kcp
+KCP|kcp
 Kerberos
 [Kk]eycloak
 [Kk]eypair


### PR DESCRIPTION
Follow-up to #111. Bare lowercase `kcp` made `Vale.Terms` enforce it as canonical and reject the established uppercase `KCP` used across handbook docs (StakaterCloudAPI.md, glossary.md — 16 occurrences). Switch to the `KCP|kcp` alternation (same pattern as `ARO|aro`, `ROSA|rosa`) so both casings pass and neither is enforced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)