### PR TITLE
feat(vocab): accept Stakater platform and Kubernetes tooling terms

### DIFF
--- a/Stakater/styles/config/vocabularies/Stakater/accept.txt
+++ b/Stakater/styles/config/vocabularies/Stakater/accept.txt
@@ -1,5 +1,6 @@
 [Aa]ccessor
 [Aa]ccreditation[s]?
+[Aa]gentic
 ACLs
 addhost
 additionalNetworks
@@ -15,6 +16,7 @@ apigroup[s]?
 APIManager
 API[s]?
 [Aa]rchitecting
+apiVersion
 ArgoCD
 ARN[s]?
 ARO|aro
@@ -96,6 +98,7 @@ cyberattack[s]?
 [Dd]ata[Cc]enter[s]?
 Datadog
 DBA[s]?
+[Dd]atasource[s]?
 declaratively
 [Dd]ecomissioning
 [Dd]eduplicate[sd]?
@@ -114,6 +117,7 @@ Dex
 [Dd]iscoverability
 dnsmasq
 [Dd]ocker
+dnsSuffix
 Docker Hub
 Dockerfile[s]?
 [Dd]owntimes
@@ -137,6 +141,7 @@ etcd
 execve
 [Ee]xfiltration
 Exoscale
+exposedAddress
 Fabrikate
 [Ff]ailback
 [Ff]ailover
@@ -172,6 +177,7 @@ Gravatar
 HAProxy
 HashiCorp
 [Hh]elm
+[Hh]ostpath
 Hive
 [Hh]ostname[s]?
 hostPort
@@ -210,6 +216,7 @@ jsonnet
 JUnit
 JWK[S]?
 JWT[s]?
+KCL|kcl
 [Kk]afka
 Kamaji
 [Kk]amel
@@ -227,6 +234,8 @@ keystore
 Kiali
 Kibana
 [Kk]ickstarter
+[Kk]ube[Ss]tack[Cc]onfig
+[Kk]ube[Ss]tack[Pp]lus
 Knative
 [Kk]ommun
 Konfigurator
@@ -235,6 +244,7 @@ ksonnet
 [Kk]ube
 Kube
 [Kk]ubeadmin
+kubebuilder
 kubeconfig
 kubectl
 KubeHealth
@@ -253,6 +263,7 @@ LDs
 Linkerd
 [Ll]inux
 [Ll]iveness
+[Ll]ookup[s]?
 localfile
 Logstash
 Macbook
@@ -267,6 +278,7 @@ MB
 Mbps
 MCP[s]?
 memcached
+mgmt
 [Mm]etamodel[s]?
 [Mm]iddleware
 mins
@@ -285,10 +297,12 @@ multipathing
 [Mm]ultitenancy
 [Mm]ultitenant
 [Mm]ultus
+[Nn]amespaced
 [Nn]amespace[s]?
 Nasdaq
 NDA[s]?
 netclient
+[Nn]et[Bb]ird(io)?
 [Nn]etmaker
 NFS
 nginx
@@ -315,6 +329,7 @@ ontop
 OpenBao
 [Oo]pen[Cc]ost
 OpenMetal
+openresolv
 OpenShift
 OpenStack
 [Oo]rg[s]?
@@ -339,6 +354,7 @@ P[Oo]C[s]?
 Portworx
 Postgres
 [Pp]owershift
+[Pp]rom[Qq][Ll]
 preloaded
 Prisma
 [Pp]roductize[d]?
@@ -356,6 +372,8 @@ Quay
 [Qq]ueryable
 [Qq]uiescing
 RBAC
+replicaCount
+resolvconf
 [Rr]eactively
 [Rr]eadiness
 Realtime
@@ -387,6 +405,7 @@ ROSA|rosa
 SAAP
 Safespring
 SAML
+secretstore
 [Ss]andboxed
 Sanitization
 Saviynt
@@ -422,6 +441,8 @@ springboot
 SRE[s]?
 SSD[s]?
 SSO
+[Ss]ubagent[s]?
+[Ss]ysctl[s]?
 StackRox
 Stakater
 stderr
@@ -520,10 +541,12 @@ webserver
 [Ww]ireguard
 Wix
 worker_state
+[Ww]orktree[s]?
 www
 xfs
 XRD[s]?
 XR[s]?
+[Xx]pkg[s]?
 YAML[s]?
 Zerotier
 Zipkin


### PR DESCRIPTION
## Why

`stakater-ab/handbook`'s `.vale.ini` carries two sections that look like an ignore list but are **inert**:

```ini
[spelling]
ignore = probe_success, datasource, mgmt, kcl, xpkg, …   # ~120 terms
[terms]
ignore = prometheus, openshift, api, …
```

Vale reads every `[...]` section header as a **file glob**, so `[spelling]` matches a file literally named `spelling` and its `ignore =` key is never consulted. Verified against vale 3.9.5: a non-exempt `src/**.md` containing `mgmt`, `kcl`, `xpkg` — all three "ignored" — throws three `Vale.Spelling` errors.

It went unnoticed because the docs using those words happen to live in the two subtrees exempted the way that *does* work (`Vale.Spelling = NO` for the ADR and networking trees). Authors writing anywhere else hit failures on terms the team already decided to accept.

This PR moves the terms that genuinely belong in shared vocabulary to where vale actually reads them. A companion handbook PR deletes the dead sections.

## How the list was chosen

Each of the 84 candidates was put in a prose sentence and run through vale 3.9.5 against `accept.txt` @ `v0.0.104`. Only the **32** actually rejected were considered; the other 52 were already covered or never flagged.

Of those 32, four are deliberately excluded — `ksa`, `oxr`, `ocds`, `probe_success`. Three-letter and `snake_case` identifiers in a spelling accept-list mask real typos; those belong in backticks in the docs.

The remaining 28 are covered by 23 entries, using the existing `[Xx]`/`[s]?` conventions. Re-running the probe leaves only those four plus three `Vale.Terms` capitalization rules that are behaving correctly (`OpenBao`, `Stakater`, `HTTP`).

Hyphenated compounds from the old list (`mesh-cloud`, `kcp-config`, `transit-unseal`, `stakater-mesh-platform`, …) are absent on purpose: vale splits on the hyphen, so the parts are already accepted.

## Verification

`vale src` over the full handbook tree: **0 errors, 325 files** before and after — this only removes future friction, it does not change today's result.